### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/controllers/api.js
+++ b/app/controllers/api.js
@@ -274,7 +274,7 @@ exports.getObjById = function(req, res) {
  * @return object
  */
 exports.getRoutableModelSchemas = function() {//TODO make this an api call
-	var uuid = require('node-uuid');
+	var uuid = require('uuid');
 	var standardProperties = mongoose.model('Routable').schema.statics.formschema;
 	var modelSchemas = {};
 	for(var key in mongoose.models) {

--- a/app/controllers/routable.js
+++ b/app/controllers/routable.js
@@ -166,7 +166,7 @@ exports.getObjById = function(req, res) {//req, res, next, err, route) {
  * @return object
  */
 exports.getRoutableModelSchemas = function() {//TODO make this an api call
-	var uuid = require('node-uuid');
+	var uuid = require('uuid');
 	var standardProperties = mongoose.model('Routable').schema.statics.formschema;
 	var modelSchemas = {};
 	for(var key in mongoose.models) {

--- a/config/express.js
+++ b/config/express.js
@@ -7,7 +7,7 @@ var 	async = require('async'),
 		passport = require('passport'),
 		swig = require('swig-templates'),
 		swigExpressLoader = require('../app/libs/swig/expressLoader'),
-		uuid = require('node-uuid'),
+		uuid = require('uuid'),
 		vhost = require('vhost');//TODO may not use this unless restricting to certain domain names
 
 

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "mongoose-schema-extend": "0.2.0",
     "nconf": "^0.8.4",
     "node-dir": "^0.1.16",
-    "node-uuid": "^1.4.7",
     "passport": "^0.3.2",
     "spdy": "^3.4.4",
     "swig-templates": "^2.0.2",
     "underscore": "^1.8.3",
+    "uuid": "^3.0.0",
     "vhost": "^3.0.2"
   },
   "engines": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.